### PR TITLE
Add UbuntuVersion.Ubuntu_21_10 support

### DIFF
--- a/src/main/java/de/flapdoodle/os/linux/UbuntuVersion.java
+++ b/src/main/java/de/flapdoodle/os/linux/UbuntuVersion.java
@@ -29,7 +29,8 @@ public enum UbuntuVersion implements Version {
   Ubuntu_19_04(OsReleaseFiles.osReleaseFileVersionMatches("19.04")),
   Ubuntu_19_10(OsReleaseFiles.osReleaseFileVersionMatches("19.10")),
   Ubuntu_20_04(OsReleaseFiles.osReleaseFileVersionMatches("20.04")),
-  Ubuntu_20_10(OsReleaseFiles.osReleaseFileVersionMatches("20.10"))
+  Ubuntu_20_10(OsReleaseFiles.osReleaseFileVersionMatches("20.10")),
+  Ubuntu_21_10(OsReleaseFiles.osReleaseFileVersionMatches("21.10"))
   ;
 
   private final List<Peculiarity> peculiarities;

--- a/src/test/java/de/flapdoodle/os/linux/UbuntuVersionTest.java
+++ b/src/test/java/de/flapdoodle/os/linux/UbuntuVersionTest.java
@@ -37,6 +37,7 @@ class UbuntuVersionTest {
     assertVersion("19.10", UbuntuVersion.Ubuntu_19_10);
     assertVersion("20.04", UbuntuVersion.Ubuntu_20_04);
     assertVersion("20.10", UbuntuVersion.Ubuntu_20_10);
+    assertVersion("21.10", UbuntuVersion.Ubuntu_21_10);
   }
 
   private static void assertVersion(String versionIdContent, UbuntuVersion version) {


### PR DESCRIPTION
Hello,

I face an issue with the use of Mongo 5.0.5 with flapdoodle. This PR adds support for Ubuntu 21.10.
If accepted the next PR will be in https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo.