### PR TITLE
add mint 21.1 support

### DIFF
--- a/src/main/java/de/flapdoodle/os/linux/LinuxMintVersion.java
+++ b/src/main/java/de/flapdoodle/os/linux/LinuxMintVersion.java
@@ -32,8 +32,9 @@ public enum LinuxMintVersion implements Version {
     LINUX_MINT_20_1(UbuntuVersion.Ubuntu_20_04, OsReleaseFiles.osReleaseFileVersionIs("20.1")),
     LINUX_MINT_20_2(UbuntuVersion.Ubuntu_20_04, OsReleaseFiles.osReleaseFileVersionIs("20.2")),
     LINUX_MINT_20_3(UbuntuVersion.Ubuntu_20_04, OsReleaseFiles.osReleaseFileVersionIs("20.3")),
-    LINUX_MINT_21_0(UbuntuVersion.Ubuntu_22_04, OsReleaseFiles.osReleaseFileVersionIs("21"));
-    
+    LINUX_MINT_21_0(UbuntuVersion.Ubuntu_22_04, OsReleaseFiles.osReleaseFileVersionIs("21")),
+    LINUX_MINT_21_1(UbuntuVersion.Ubuntu_22_04, OsReleaseFiles.osReleaseFileVersionIs("21.1"));
+
     private final UbuntuVersion matchingUbuntuVersion;
     private final List<Peculiarity> peculiarities;
 
@@ -45,7 +46,7 @@ public enum LinuxMintVersion implements Version {
     public UbuntuVersion matchingUbuntuVersion() {
         return matchingUbuntuVersion;
     }
-    
+
     @Override
     public List<Peculiarity> pecularities() {
         return peculiarities;

--- a/src/test/java/de/flapdoodle/os/linux/LinuxMintVersionTest.java
+++ b/src/test/java/de/flapdoodle/os/linux/LinuxMintVersionTest.java
@@ -41,6 +41,7 @@ class LinuxMintVersionTest {
     assertVersion("20.2", LinuxMintVersion.LINUX_MINT_20_2, UbuntuVersion.Ubuntu_20_04);
     assertVersion("20.3", LinuxMintVersion.LINUX_MINT_20_3, UbuntuVersion.Ubuntu_20_04);
     assertVersion("21", LinuxMintVersion.LINUX_MINT_21_0, UbuntuVersion.Ubuntu_22_04);
+    assertVersion("21.1", LinuxMintVersion.LINUX_MINT_21_1, UbuntuVersion.Ubuntu_22_04);
   }
 
   private static void assertVersion(String versionIdContent, LinuxMintVersion version, UbuntuVersion matchingUbuntuVersion) {


### PR DESCRIPTION
This should fix:
`could not resolve package for PRODUCTION:Platform{operatingSystem=Linux, architecture=X86_64, distribution=LinuxMint}`
when using [Linux Mint 21.1](https://www.linuxmint.com/rel_vera_cinnamon_whatsnew.php)