### PR TITLE
Add Fedora 39 as valid version

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Sample value for macOs on x86 with 64bit: `OS_X|X86_64`, Centos7 on 32bit x86: `
 
 ### Changelog
 
+#### 1.5.2
+
+- fedora 39
+
 #### 1.5.1
 
 - debian 12, 13

--- a/src/main/java/de/flapdoodle/os/linux/FedoraVersion.java
+++ b/src/main/java/de/flapdoodle/os/linux/FedoraVersion.java
@@ -26,7 +26,7 @@ import static de.flapdoodle.os.linux.OsReleaseFiles.versionMatches;
 
 public enum FedoraVersion implements Version {
 	Fedora_38(versionMatches(OsReleaseFiles.osReleaseFile(),"38")),
-	;
+    Fedora_39(versionMatches(OsReleaseFiles.osReleaseFile(),"39"));
 
 	private final List<Peculiarity> peculiarities;
 

--- a/src/test/java/de/flapdoodle/os/linux/FedoraVersionTest.java
+++ b/src/test/java/de/flapdoodle/os/linux/FedoraVersionTest.java
@@ -34,6 +34,7 @@ class FedoraVersionTest {
 	@Test
 	public void versionIdMustMatchVersion() {
 		assertVersion("38", FedoraVersion.Fedora_38);
+		assertVersion("39", FedoraVersion.Fedora_39);
 	}
 
 	private static void assertVersion(String versionIdContent, FedoraVersion version) {


### PR DESCRIPTION
Hi @michaelmosmann, Fedora 39 came out last week and I added support for it. Corresponding pull request is also https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo.packageresolver/pull/8