### PR TITLE
add Fedora versions up to 45

### DIFF
--- a/src/main/java/de/flapdoodle/os/linux/FedoraVersion.java
+++ b/src/main/java/de/flapdoodle/os/linux/FedoraVersion.java
@@ -29,6 +29,10 @@ public enum FedoraVersion implements Version {
 	Fedora_39(versionMatches(OsReleaseFiles.osReleaseFile(), "39")),
 	Fedora_40(versionMatches(OsReleaseFiles.osReleaseFile(), "40")),
 	Fedora_41(versionMatches(OsReleaseFiles.osReleaseFile(), "41")),
+	Fedora_42(versionMatches(OsReleaseFiles.osReleaseFile(), "42")),
+	Fedora_43(versionMatches(OsReleaseFiles.osReleaseFile(), "43")),
+	Fedora_44(versionMatches(OsReleaseFiles.osReleaseFile(), "44")),
+	Fedora_45(versionMatches(OsReleaseFiles.osReleaseFile(), "45")),
 	;
 
 	private final List<Peculiarity> peculiarities;

--- a/src/test/java/de/flapdoodle/os/linux/FedoraVersionTest.java
+++ b/src/test/java/de/flapdoodle/os/linux/FedoraVersionTest.java
@@ -37,6 +37,10 @@ class FedoraVersionTest {
 		assertVersion("39", FedoraVersion.Fedora_39);
 		assertVersion("40", FedoraVersion.Fedora_40);
 		assertVersion("41", FedoraVersion.Fedora_41);
+		assertVersion("42", FedoraVersion.Fedora_42);
+		assertVersion("43", FedoraVersion.Fedora_43);
+		assertVersion("44", FedoraVersion.Fedora_44);
+		assertVersion("45", FedoraVersion.Fedora_45);
 	}
 
 	private static void assertVersion(String versionIdContent, FedoraVersion version) {


### PR DESCRIPTION
Given the release cycle of Red hat rel 9 will still be the active release version when Fedora 45 is released